### PR TITLE
Allow raw when to_json

### DIFF
--- a/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
@@ -153,11 +153,10 @@ module BetterHtml
         def no_unsafe_calls(parent_node, ruby_node)
           raw_error = false
           to_json_input_to_raw = false
+          
           ruby_node.descendants(:send, :csend).each do |call|
             if call.method_name?(:raw)
-              puts "found raw error"
               raw_error = true
-              
             elsif call.method_name?(:html_safe)
               add_error(
                 "erb interpolation with '<%= (...).html_safe %>' in this context is never safe",
@@ -170,15 +169,11 @@ module BetterHtml
             end
           end
 
-          if raw_error
-            if to_json_input_to_raw
-              puts "WILL NOT ERROR"
-            else 
-              add_error(
-                "erb interpolation with '<%= raw(...) %>' in this context is never safe",
-                location: nested_location(parent_node, ruby_node)
-              )
-            end
+          if raw_error && !to_json_input_to_raw
+            add_error(
+              "erb interpolation with '<%= raw(...) %>' in this context is never safe",
+              location: nested_location(parent_node, ruby_node)
+            )
           end
         end
 

--- a/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
@@ -159,7 +159,7 @@ module BetterHtml
               raw_error = true
             elsif call.method_name?(:html_safe)
               add_error(
-                "erb interpolation with '<%= (...).html_safe %>' in this context is never safe",
+                "erb interpolation with '<%= (...).html_safe %>' in this context may introduce XSS. Please request security review.",
                 location: nested_location(parent_node, ruby_node)
               )
             end
@@ -171,7 +171,7 @@ module BetterHtml
 
           if raw_error && !to_json_input_to_raw
             add_error(
-              "erb interpolation with '<%= raw(...) %>' in this context is never safe",
+              "erb interpolation with '<%= raw(...) %>' without .to_json may introduce XSS. Please request security review.",
               location: nested_location(parent_node, ruby_node)
             )
           end


### PR DESCRIPTION
As noted in this prior issue https://github.com/Shopify/erb-lint/issues/95 by @avit it is often desirable or necessary to pass `something.to_json` to raw, and the `to_json` alleviates the usual safety concerns. However better-html's safety scanner does not account for this.

This adds a very basic bit of custom logic to solve this. If we see that the input to raw has .to_json called on it, we do not throw an error. 